### PR TITLE
fix(ci): use Node 24 release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
           name: release-binaries
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             forge-previewer-linux-x86_64


### PR DESCRIPTION
## Summary

- upgrade softprops/action-gh-release from v2 to v3
- remove the final Node.js 20 runtime warning from release jobs

## Validation

- actionlint .github/workflows/release.yml .github/workflows/tests.yml
- v3 is the upstream Node.js 24 release line